### PR TITLE
Fixing the E2E test fallout from changing the restart command

### DIFF
--- a/test/specs/apexLsp.e2e.ts
+++ b/test/specs/apexLsp.e2e.ts
@@ -8,7 +8,7 @@
 import { TestSetup } from '../testSetup';
 import * as utilities from '../utilities/index';
 import { EnvironmentSettings } from '../environmentSettings';
-import { By, InputBox, QuickPickItem, WebElement, after } from 'vscode-extension-tester';
+import { By, InputBox, WebElement, after } from 'vscode-extension-tester';
 import path from 'path';
 import fs from 'fs';
 import { step } from 'mocha-steps';


### PR DESCRIPTION
Fixing the E2E test fallout from changing the restart command to use the command palette quick picker for options instead of a notification since that is slightly covered by the LSP status bar item. 