### PR TITLE
fix: remove the check for text that no longer exists from Apex Replay Debugger E2E test

### DIFF
--- a/test/specs/apexReplayDebugger.e2e.ts
+++ b/test/specs/apexReplayDebugger.e2e.ts
@@ -311,9 +311,6 @@ describe('Apex Replay Debugger', async () => {
       10
     );
     expect(outputPanelText).to.not.be.undefined;
-    expect(outputPanelText).to.contain('Deleting Record...');
-    expect(outputPanelText).to.contain('Success');
-    expect(outputPanelText).to.contain('Successfully deleted record:');
     expect(outputPanelText).to.contain('ended with exit code 0');
   });
 


### PR DESCRIPTION
Recently we changed the `SFDX: Turn Off Apex Debug Log for Replay Debugger` command to not run the CLI command.  This caused some text that was previously shown in the Output Tab to no longer be printed.  This PR removed the check for that text from the Apex Replay Debugger E2E test.

Passing E2E test run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/15021587317 ✅ 