### PR TITLE
fix: close the Welcome tab before starting the SOQL E2E test

### DIFF
--- a/test/specs/soql.e2e.ts
+++ b/test/specs/soql.e2e.ts
@@ -22,6 +22,7 @@ describe('SOQL', async () => {
 
   step('Set up the testing environment', async () => {
     testSetup = await TestSetup.setUp(testReqConfig);
+    await utilities.executeQuickPick('View: Close All Editors');
   });
 
   step('SFDX: Create Query in SOQL Builder', async () => {

--- a/test/specs/soql.e2e.ts
+++ b/test/specs/soql.e2e.ts
@@ -22,7 +22,6 @@ describe('SOQL', async () => {
 
   step('Set up the testing environment', async () => {
     testSetup = await TestSetup.setUp(testReqConfig);
-    await utilities.executeQuickPick('View: Close All Editors');
   });
 
   step('SFDX: Create Query in SOQL Builder', async () => {

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -18,7 +18,7 @@ export class TestSetup {
   public scratchOrgAliasName: string | undefined;
   public scratchOrgId: string | undefined;
 
-  private constructor() {}
+  private constructor() { }
 
   public get tempProjectName(): string {
     return 'TempProject-' + this.testSuiteSuffixName;
@@ -31,6 +31,7 @@ export class TestSetup {
     utilities.log(`${testSetup.testSuiteSuffixName} - Starting TestSetup.setUp()...`);
     /* The expected workspace will be open up after setUpTestingWorkspace */
     await testSetup.setUpTestingWorkspace(testReqConfig.projectConfig);
+    await utilities.executeQuickPick('View: Close All Editors');
     if (testReqConfig.projectConfig.projectShape !== ProjectShapeOption.NONE) {
       await utilities.verifyExtensionsAreRunning(utilities.getExtensionsToVerifyActive());
       const scratchOrgEdition = testReqConfig.scratchOrgEdition || 'developer';


### PR DESCRIPTION
The SOQL E2E test was failing on VSCode version v1.90.0 because there were 4 tabs and we were expecting 3.  This PR adds a line to close all tabs after the setup step, before the SOQL steps are run.

E2E test runs:
- 1.90.0: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/15126699456
- latest: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/15126702931