### PR TITLE
feat: don't assert that soql is running

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/salesforcedx-vscode-test-tools",
-  "version": "1.0.1-dev.18",
+  "version": "1.0.1-dev.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/salesforcedx-vscode-test-tools",
-      "version": "1.0.1-dev.18",
+      "version": "1.0.1-dev.22",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.3",

--- a/src/testing/extensionUtils.ts
+++ b/src/testing/extensionUtils.ts
@@ -34,7 +34,7 @@ export const extensions: ExtensionType[] = [
     name: 'SOQL',
     vsixPath: '',
     shouldInstall: 'optional',
-    shouldVerifyActivation: true
+    shouldVerifyActivation: false
   },
   {
     extensionId: 'salesforcedx-einstein-gpt',


### PR DESCRIPTION
I have a PR on vscode so that soql when run when it's called on.  it won't always run at startup.

I'm adjusting the e2e for that change, in advance