### PR TITLE
ci: correct GHA workflows for publishing releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,11 @@ on:
       tag:
         required: true
         type: string
+        description: 'Git tag to checkout'
+      distTag:
+        required: false
+        type: string
+        description: 'NPM dist tag for publishing'
       nodeVersion:
         required: true
         type: string
@@ -45,6 +50,6 @@ jobs:
         id: distTag
 
       - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.distTag.outputs.tag }}
+        run: npm publish --access public --tag ${{ inputs.distTag || steps.distTag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -16,6 +16,7 @@ jobs:
   getDistTag:
     outputs:
       tag: ${{ steps.distTag.outputs.tag }}
+      gitTag: ${{ github.event.release.tag_name || inputs.tag }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,9 +26,11 @@ jobs:
         id: distTag
 
   npm-publish:
+    if: ${{ needs.getDistTag.outputs.tag != '' }}
     uses: ./.github/workflows/npm-publish.yml
     needs: [getDistTag]
     with:
-      tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
+      tag: ${{ needs.getDistTag.outputs.gitTag }}
+      distTag: ${{ needs.getDistTag.outputs.tag }}
       nodeVersion: 'lts/*'
     secrets: inherit


### PR DESCRIPTION
Currently publishes to NPMJS are failing after the tag is created in Github.  I fixed the **npm-publish.yml** and **onRelease.yml** workflows to one that allows publishes to succeed.  The workflows were tested with over 10 releases in the **daphne/W-19111839-fs-write-for-e2e-tests** branch.

[skip-validate-pr]