### PR TITLE
W-18759649: fix: move window.dialogStyle to before creating any classes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           npm test
 
   windows-basic-tests:
-    needs: ubuntu-basic-tests
+    needs: package-lock-check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -24,7 +24,7 @@ import {
   checkForUncaughtErrors,
   extensions,
 } from './testing';
-import { executeQuickPick, verifyProjectLoaded } from './ui-interaction';
+import { executeQuickPick, reloadWindow, verifyProjectLoaded } from './ui-interaction';
 import { setUpScratchOrg } from './salesforce-components';
 import { retryOperation } from './retryUtils';
 
@@ -71,6 +71,9 @@ export class TestSetup {
     testSetup.setWindowDialogStyle();
     testSetup.setWorkbenchHoverDelay();
     testSetup.setMaximumWindowSize();
+
+    await reloadWindow(); // reload window to apply settings
+
     core.log(`${testSetup.testSuiteSuffixName} - ...finished TestSetup.setUp()`);
     return testSetup;
   }

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -52,7 +52,6 @@ export class TestSetup {
     testSetup.testSuiteSuffixName = testReqConfig.testSuiteSuffixName;
     core.log('');
     core.log(`${testSetup.testSuiteSuffixName} - Starting TestSetup.setUp()...`);
-    testSetup.setWindowDialogStyle();
 
     // Configure extensions based on test requirements
     testSetup.configureExtensions(testReqConfig);
@@ -69,6 +68,7 @@ export class TestSetup {
       }
       await reloadAndEnableExtensions(); // This is necessary in order to update JAVA home path
     }
+    testSetup.setWindowDialogStyle();
     testSetup.setWorkbenchHoverDelay();
     testSetup.setMaximumWindowSize();
     core.log(`${testSetup.testSuiteSuffixName} - ...finished TestSetup.setUp()`);

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -17,7 +17,6 @@ import {
   getRepoNameFromUrl,
   getFolderName,
   gitClone,
-  setSettingValue
 } from './system-operations';
 import {
   verifyExtensionsAreRunning,
@@ -53,6 +52,7 @@ export class TestSetup {
     testSetup.testSuiteSuffixName = testReqConfig.testSuiteSuffixName;
     core.log('');
     core.log(`${testSetup.testSuiteSuffixName} - Starting TestSetup.setUp()...`);
+    testSetup.setWindowDialogStyle();
 
     // Configure extensions based on test requirements
     testSetup.configureExtensions(testReqConfig);
@@ -246,7 +246,6 @@ export class TestSetup {
         }
       });
     }
-    await setSettingValue("window.dialogStyle", "custom", false);
   }
 
   private throwError(message: string) {
@@ -335,5 +334,28 @@ export class TestSetup {
 
     fs.writeFileSync(vscodeSettingsPath, JSON.stringify(settings, null, 2), 'utf8');
     core.log(`${this.testSuiteSuffixName} - Set 'window.newWindowDimensions' to 'maximized' in ${vscodeSettingsPath}`);
+  }
+
+  private setWindowDialogStyle(): void {
+    if (!this.projectFolderPath) {
+      this.throwError('Project folder path is not set');
+      return; // This line will never be reached, but helps TypeScript understand
+    }
+    const vscodeSettingsPath = path.join(this.projectFolderPath, '.vscode', 'settings.json');
+
+    if (!fs.existsSync(path.dirname(vscodeSettingsPath))) {
+      fs.mkdirSync(path.dirname(vscodeSettingsPath), { recursive: true });
+    }
+
+    let settings = fs.existsSync(vscodeSettingsPath) ? JSON.parse(fs.readFileSync(vscodeSettingsPath, 'utf8')) : {};
+
+    // Update settings to set window.dialogStyle
+    settings = {
+      ...settings,
+      'window.dialogStyle': 'custom'
+    };
+
+    fs.writeFileSync(vscodeSettingsPath, JSON.stringify(settings, null, 2), 'utf8');
+    core.log(`${this.testSuiteSuffixName} - Set 'window.dialogStyle' to 'custom' in ${vscodeSettingsPath}`);
   }
 }


### PR DESCRIPTION
@W-18759649@

This change is not directly related to ticket, but should help "overwrite not clickable" error on retries. 