### PR TITLE
W-20518276 : fix: incorrect paths in package json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/salesforcedx-vscode-test-tools",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/salesforcedx-vscode-test-tools",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@salesforce/salesforcedx-vscode-test-tools",
   "version": "1.2.4",
   "description": "Test automation framework for Salesforce Extensions for VS Code",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/src/index.js",
+  "types": "lib/src/index.d.ts",
   "files": [
     "lib",
     "src",


### PR DESCRIPTION
Bug:
- There is a bug in test-tools repo, where main/type paths defined in package.json don't reflect where the code is generated too. The difference is lib/index.js vs lib/src/index.js .

Why does it currently work?:
- This works in vscode because we have bypassed the main by imports like from '@salesforce/salesforcedx-vscode-test-tools/lib/src/core';

Fix: in current PR

Will this break current vscode repo?:
- No it won't since we are changing the output of the repo but fixing the index/type paths in package.json so future imports don't need to bypass main definition.

@W-20518276@
