### PR TITLE
fix(security): support new versions of CLI that redact sensitive info in `sf org display` - W-22570669

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/salesforcedx-vscode-test-tools",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/salesforcedx-vscode-test-tools",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.3",

--- a/src/system-operations/cliCommands.ts
+++ b/src/system-operations/cliCommands.ts
@@ -127,24 +127,61 @@ export async function orgLoginSfdxUrl(): Promise<SfCommandRunResults> {
 }
 
 /**
- * Displays information about a Salesforce org
+ * Displays information about a Salesforce org, including sensitive credentials.
+ * Merges results from `sf org display` with the new dedicated credential commands
+ * (`sf org auth show-access-token` and `sf org auth show-sfdx-auth-url`) introduced
+ * in the May 27 2026 CLI security update that redacted secrets from `org display`.
  * @param usernameOrAlias - Username or alias of the org to display
- * @returns Results of the org display command
- * @throws Error if the command fails
+ * @returns Results of the org display command with accessToken and sfdxAuthUrl merged in
+ * @throws Error if any of the underlying commands fail
  */
 export async function orgDisplay(usernameOrAlias: string | undefined): Promise<SfCommandRunResults> {
   if (!usernameOrAlias) {
     throw new Error('No usernameOrAlias provided');
   }
 
-  const sfOrgDisplayResult = await runCliCommand('org:display', '--target-org', usernameOrAlias, '--verbose', '--json');
+  const [sfOrgDisplayResult, accessTokenResult, sfdxAuthUrlResult] = await Promise.all([
+    runCliCommand('org:display', '--target-org', usernameOrAlias, '--json'),
+    runCliCommand('org:auth:show-access-token', '--target-org', usernameOrAlias, '--json', '--no-prompt'),
+    runCliCommand('org:auth:show-sfdx-auth-url', '--target-org', usernameOrAlias, '--json', '--no-prompt')
+  ]);
+
   if (sfOrgDisplayResult.exitCode > 0) {
     const message = `sf org display failed with exit code: ${sfOrgDisplayResult.exitCode}.\n${sfOrgDisplayResult.stderr}`;
     log(message);
     throw new Error(message);
   }
-  debug(`orgDisplay results ${JSON.stringify(sfOrgDisplayResult)}`);
-  return sfOrgDisplayResult;
+  if (accessTokenResult.exitCode > 0) {
+    const message = `sf org auth show-access-token failed with exit code: ${accessTokenResult.exitCode}.\n${accessTokenResult.stderr}`;
+    log(message);
+    throw new Error(message);
+  }
+  if (sfdxAuthUrlResult.exitCode > 0) {
+    const message = `sf org auth show-sfdx-auth-url failed with exit code: ${sfdxAuthUrlResult.exitCode}.\n${sfdxAuthUrlResult.stderr}`;
+    log(message);
+    throw new Error(message);
+  }
+
+  const displayJson = JSON.parse(sfOrgDisplayResult.stdout);
+  const accessTokenJson = JSON.parse(accessTokenResult.stdout);
+  const sfdxAuthUrlJson = JSON.parse(sfdxAuthUrlResult.stdout);
+
+  const merged = {
+    ...displayJson,
+    result: {
+      ...displayJson.result,
+      accessToken: accessTokenJson.result?.accessToken,
+      sfdxAuthUrl: sfdxAuthUrlJson.result?.sfdxAuthUrl
+    }
+  };
+
+  const mergedResult: SfCommandRunResults = {
+    ...sfOrgDisplayResult,
+    stdout: JSON.stringify(merged)
+  };
+
+  debug(`orgDisplay results ${JSON.stringify(mergedResult)}`);
+  return mergedResult;
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?
As announced in https://github.com/forcedotcom/cli/issues/3560, the `sf org display` CLI command will redact the access token and sfdx auth url starting from 5/27/2026.  This PR migrates the `orgDisplay()` utility function in **cliCommands.ts** to call the new `sf org auth show-access-token` and `sf org auth show-sfdx-auth-url` commands instead to continue using that info.  No functionality change.

### What issues does this PR fix or reference?
@W-22570669@, https://github.com/forcedotcom/cli/issues/3560